### PR TITLE
Fix long links breaking layout in prose content

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -56,6 +56,11 @@ h1, h2, h3, h4, h5, h6 {
   text-wrap: balance;
 }
 
+.prose a {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
 .filter-btn.active {
   background-color: var(--accent);
   color: white;


### PR DESCRIPTION
## Summary
Added word-breaking styles to prose links to prevent long URLs from breaking the layout and causing horizontal overflow.

## Changes
- Added CSS rules to `.prose a` elements with `overflow-wrap: break-word` and `word-break: break-word` properties
- This ensures that long links will wrap or break at word boundaries instead of overflowing their container

## Implementation Details
The fix targets prose content specifically by using the `.prose a` selector, which is commonly used in documentation and content-heavy layouts. The dual approach of using both `overflow-wrap` and `word-break` ensures broad browser compatibility for handling long unbreakable strings like URLs.

https://claude.ai/code/session_0188qMLKQKoyrFswXkBbwT3S